### PR TITLE
Added more flutter/dismissible like behavior

### DIFF
--- a/lib/swipeable.dart
+++ b/lib/swipeable.dart
@@ -1,4 +1,5 @@
 library swipeable;
+
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';


### PR DESCRIPTION
This pull request extends the functionality by providing two seperate backgrounds depending on the swipe direction. Also the background will be now filled to the whole tile and be clipped behind the child like in flutter/dismissible.